### PR TITLE
update: correct the required PHP version in webinstall.php

### DIFF
--- a/webinstall.php
+++ b/webinstall.php
@@ -130,9 +130,11 @@ switch ($do) {
 $check_pass = true;
 $server_check_errors = array();
 
-if (version_compare(phpversion(), "8.1.0", "<=")) {
+$required_php_version = "7.3"; /* the required PHP version number*/
+
+if (version_compare(phpversion(), $required_php_version , "<=")) {
     $check_pass = false;
-    $server_check_errors['php_version'] = 'You must run PHP 7.3 or greater';
+    $server_check_errors['php_version'] = 'You must run PHP $required_php_version or greater';
 }
 if (!function_exists('curl_init')) {
     $check_pass = false;


### PR DESCRIPTION
There was a conflict, when trying to install microweber, it issues an error of "You must run PHP 7.3 or greater" while my current PHP version is 7.4.8. In addition, separate the $required_php_version for the dynamic requirement of updates, instead of updating each line.
NOTE: IF the required PHP version is 8.1.0  please fix the code with consideration of many web hosting service providers that have not updated their PHP version.